### PR TITLE
Fixed CSS parsing

### DIFF
--- a/src/services/css-gen/css-gen.ts
+++ b/src/services/css-gen/css-gen.ts
@@ -794,7 +794,7 @@ export class CSSGen {
   }
 
   private hydratePseudoClasses(pseudoClass: string) {
-    if (!CSSGen.isStyleWindClass(pseudoClass)) return pseudoClass + ';';
+    if (!CSSGen.isStyleWindClass(pseudoClass)) return `${pseudoClass};`;
 
     const sm = this.config.theme.screens.sm;
     const md = this.config.theme.screens.md;

--- a/src/services/css-gen/css-gen.ts
+++ b/src/services/css-gen/css-gen.ts
@@ -794,7 +794,7 @@ export class CSSGen {
   }
 
   private hydratePseudoClasses(pseudoClass: string) {
-    if (!CSSGen.isStyleWindClass(pseudoClass)) return pseudoClass;
+    if (!CSSGen.isStyleWindClass(pseudoClass)) return pseudoClass + ';';
 
     const sm = this.config.theme.screens.sm;
     const md = this.config.theme.screens.md;


### PR DESCRIPTION
# Description

Added a `;` in `hydratePseudoClasses` method. This method has a check for `isStyleWindClass` which will be filtered out `.` or `swind` style classes and returns the only pseudo-class. 

Fixes #15 

## Type of change

Please delete options that are not relevant.

- [ ✅ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- I have tested using all the supported class names and style elements

# Checklist:

- [✅  ] My code follows the style guidelines of this project
- [✅  ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ✅ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ✅ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
