### PR TITLE
fix: error in getBorderRadiusDirection function

### DIFF
--- a/src/services/css-gen/css-gen.ts
+++ b/src/services/css-gen/css-gen.ts
@@ -645,8 +645,8 @@ export class CSSGen {
             }
             case 'r': {
               return `
-                  border-top-right-radius: 0.25rem;
-                  border-bottom-right-radius: 0.25rem;
+                  border-top-right-radius: ${radiusValue};
+                  border-bottom-right-radius: ${radiusValue};
                 `;
             }
             case 'tl': {
@@ -657,6 +657,11 @@ export class CSSGen {
             case 'tr': {
               return `
                   border-top-right-radius: ${radiusValue};
+                `;
+            }
+            case 'bl': {
+              return `
+                  border-bottom-left-radius: ${radiusValue};
                 `;
             }
             case 'br': {


### PR DESCRIPTION
# Description

1. Added switch case for 'bl' i.e. `border-bottom-left-radius` CSS property 
2. Rectified switch case 'r' by making it use radius value from `radiusValue` variable


Fixes #18 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Wrote test case locally to check if changes made fixes the issue.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
