### PR TITLE
fix: css generation logic

### DIFF
--- a/src/styled/styled.tsx
+++ b/src/styled/styled.tsx
@@ -1,39 +1,6 @@
 import { DOMElement, domElements } from '../utils/dom-elements';
 import styled, { AnyStyledComponent } from 'styled-components';
-import { CSSGen } from '../services/css-gen/css-gen';
-import generateStylesJS from '../utils/generateStylesJS';
-
-const windowObj: any = window;
-const customConfig = windowObj?.__STYLED_WIND_CUSTOM_CONFIG__ || {};
-
-const config = generateStylesJS(customConfig);
-const cssGen = new CSSGen(config);
-
-const getHydratedTemplateString = (strings: TemplateStringsArray): any => {
-  const sanitizedStyles = strings.map((stringsPart) => {
-    /**
-     * styled.div`
-     *  .text-red-600;
-     *  margin-top: 50px;
-     * `
-     *
-     * We will go through all the classes and replace tailwind css with the
-     * exact css value.
-     *
-     */
-    return stringsPart
-      .split(';')
-      .map((style) => {
-        if (style.trim().startsWith('.')) {
-          return cssGen.genCSS(style.trim()).trim().replace(';;', ';');
-        }
-        return style;
-      })
-      .join(';');
-  });
-
-  return sanitizedStyles;
-};
+import { getHydratedTemplateString } from '../utils/getHydratedTemplateString';
 
 const styledWrapper:
   | Record<DOMElement, string>

--- a/src/styled/styled.tsx
+++ b/src/styled/styled.tsx
@@ -9,32 +9,30 @@ const customConfig = windowObj?.__STYLED_WIND_CUSTOM_CONFIG__ || {};
 const config = generateStylesJS(customConfig);
 const cssGen = new CSSGen(config);
 
-const getHydratedTemplateString = (strings: TemplateStringsArray) => {
+const getHydratedTemplateString = (strings: TemplateStringsArray): any => {
   const sanitizedStyles = strings.map((stringsPart) => {
-    const classes = stringsPart.split(';');
-    /*
-      This is to handle the following case
-
-      margin-top: ${(props: any) => props.margin};
-     .text-yellow-900;
-
-     if we don't do this then we might miss the ; from `margin-top` style
-     and style wind style will be applied in the same line leading to
-
-     margin-top: 20pxcolor:#fff;
-    */
-    if (classes[0].length === 0) {
-      return [';', ...classes];
-    } else {
-      return classes;
-    }
+    /**
+     * styled.div`
+     *  .text-red-600;
+     *  margin-top: 50px;
+     * `
+     *
+     * We will go through all the classes and replace tailwind css with the
+     * exact css value.
+     *
+     */
+    return stringsPart
+      .split(';')
+      .map((style) => {
+        if (style.trim().startsWith('.')) {
+          return cssGen.genCSS(style.trim()).trim().replace(';;', ';');
+        }
+        return style;
+      })
+      .join(';');
   });
 
-  return sanitizedStyles.map((sanitizedStyle) => {
-    return sanitizedStyle.map((style) => {
-      return cssGen.genCSS(style.trim()).trim();
-    });
-  }) as any;
+  return sanitizedStyles;
 };
 
 const styledWrapper:

--- a/src/utils/getHydratedTemplateString.spec.ts
+++ b/src/utils/getHydratedTemplateString.spec.ts
@@ -1,0 +1,106 @@
+import { getHydratedTemplateString } from './getHydratedTemplateString';
+
+const getStringTemplate = (...args: any) => {
+  return args[0];
+};
+
+const removeLineBreaks = (styles: string[]) => {
+  return styles.map((style: string) =>
+    style.split('\n').join('').replace(/ /g, '')
+  );
+};
+
+const hasDifferentStyles = (
+  generatedStyles: string[],
+  expectedStyles: string[]
+) => {
+  const parsedGeneratedStyles = removeLineBreaks(generatedStyles);
+  const parsedExpectedStyles = removeLineBreaks(expectedStyles);
+
+  const hasDifferentStyle = parsedGeneratedStyles.filter(
+    (style: string, index: number) =>
+      style.trim() !== parsedExpectedStyles[index].trim()
+  );
+
+  return Boolean(hasDifferentStyle.length);
+};
+
+/**
+ * Test the core logic of converting Tailwind classes to their
+ * respective style equivalent.
+ *
+ * Testing done for the first argument of taged template literal
+ * which require transformation and is than sent over to styled tag
+ * from styled-components.
+ */
+describe('Tailwind Classes Hydration', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should generate correct styles for tailwind classes', () => {
+    const generatedStyles = getHydratedTemplateString`
+        .p-2;
+        .mt-2;
+      `;
+
+    const expectedStyles = getStringTemplate`
+        padding: 0.5rem;
+        margin-top: 0.5rem;
+      `;
+    expect(hasDifferentStyles(generatedStyles, expectedStyles)).toBeFalsy();
+  });
+
+  it('should generate correct styles for tailwind classes and custom styles', () => {
+    const generatedStyles = getHydratedTemplateString`
+        .pt-2;
+        color: red;
+        .mt-2;
+        font-size: 10px;
+      `;
+
+    const expectedStyles = getStringTemplate`
+        padding-top: 0.5rem;
+        color: red;
+        margin-top: 0.5rem;
+        font-size: 10px;
+      `;
+
+    expect(hasDifferentStyles(generatedStyles, expectedStyles)).toBeFalsy();
+  });
+
+  it('should generate correct styles for pseudo classes', () => {
+    const generatedStyles = getHydratedTemplateString`
+        .pt-2;
+        swind-hover: p-4;
+      `;
+
+    const expectedStyles = getStringTemplate`
+        padding-top: 0.5rem;
+        &:hover {
+          padding: 1rem
+        };
+      `;
+
+    expect(hasDifferentStyles(generatedStyles, expectedStyles)).toBeFalsy();
+  });
+
+  it('should generate correct styles with dynamic accessor', () => {
+    const generatedStyles = getHydratedTemplateString`
+        .pt-2;
+        swind-hover: p-4;
+        color: ${() => 'red'};
+        border: ${() => '1px solid black'};
+      `;
+
+    const expectedStyles = getStringTemplate`
+        padding-top: 0.5rem;
+        &:hover {
+          padding: 1rem
+        };
+        color: ${() => 'red'};
+        border: ${() => '1px solid black'};
+      `;
+    expect(hasDifferentStyles(generatedStyles, expectedStyles)).toBeFalsy();
+  });
+});

--- a/src/utils/getHydratedTemplateString.ts
+++ b/src/utils/getHydratedTemplateString.ts
@@ -1,0 +1,33 @@
+import { CSSGen } from '../services/css-gen/css-gen';
+import generateStylesJS from './generateStylesJS';
+
+const windowObj: any = window;
+const customConfig = windowObj?.__STYLED_WIND_CUSTOM_CONFIG__ || {};
+
+const config = generateStylesJS(customConfig);
+const cssGen = new CSSGen(config);
+
+export const getHydratedTemplateString = (
+  strings: TemplateStringsArray
+): any => {
+  const sanitizedStyles = strings.map((stringsPart) => {
+    /*
+        Convert tailwind classes to their CSS equivalent and pass the result 
+        to styled tag from styled-components.
+        
+        Fixes: https://github.com/product-ride/styled-wind/issues/16
+        Ref: https://github.com/product-ride/styled-wind/pull/21
+    */
+    return stringsPart
+      .split(';')
+      .map((style) => {
+        if (style.trim().startsWith('.') || style.trim().startsWith('swind')) {
+          return cssGen.genCSS(style.trim()).trim().replace(';', '');
+        }
+        return style;
+      })
+      .join(';');
+  });
+
+  return sanitizedStyles;
+};


### PR DESCRIPTION
# Description

Currently, the CSS generated logic fails when we add multiple dynamic properties. The reason being we are not generating the right format of array required by `styled` template literal of `styled-component` which breaks the styles.  

Fixes #16 

`Note:` this PR was created based on the consideration that the main function of `getHydratedTemplateString`  is to replace the tailwind class with the correct CSS value.

____
### Explanation of the changes:

Consider I am having the below styles: 

```
const Container = styled.div`
  .text-red-600;
  margin-top: ${(props) => props.margin};
  background: ${(props) => (props.error ? 'red' : 'black')};
  border: ${(props) => (props.border ? '2px solid black' : 'none')};
 .p-2
`
```

So the template literal will break wherever functions are present and pass those functions on the subsequent arguments.

In `styledWrapper` we will get the following first argument:

![image](https://user-images.githubusercontent.com/22376783/100445091-88b8a600-30d2-11eb-8336-f7b93b7674a0.png)

After passing these strings in `getHydratedTemplateString` we return the following strings to be passed in `styled.attr` from `styled-component`

![image](https://user-images.githubusercontent.com/22376783/100445151-a0902a00-30d2-11eb-9218-9bcc19ef30a3.png)

And also pass all the expressions added in the CSS. Now `styled-components` will take care of adding the styles to the DOM and combining them with the correct expression.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Currently, I generated a build and copied that file in the App itself and tested by importing `styledWrapper` but `styled.div` was getting errors but when I tested with `styled('div')` it seems to work fine.

Tested with below code: 
```
const Banner = styled('div')`
  .text-red-600;
  margin-top: ${(props) => props.margin};
  background: ${(props) => (props.error ? 'red' : 'black')};
  border: ${(props) => (props.border ? '2px solid black' : 'none')};
  .p-6;
`;

const App = () => {
  const [a, setA] = React.useState(true);
  return (
    <>
      <Banner
        error={a}
        border={a}
        onClick={() => {
          setA(!a);
        }}
        margin='40px'
      >
        hello
      </Banner>
    </>
  );
};
```

Testing Video: https://www.loom.com/share/3e13ea376ec24ffb8321940d8c1a2c84

<details>
  <summary>Lib file that I used to check working</summary>

 ```
var getHydratedTemplateString = function getHydratedTemplateString(strings) {
  var sanitizedStyles = strings.map(function (stringsPart) {
    var classes = stringsPart.split(';');
    return classes
      .map(function (style) {
        if (style.trim().startsWith('.')) {
          return cssGen.genCSS(style.trim()).trim().replace(';;', ';');
        }

        return style;
      })
      .join(';');
  });
  return sanitizedStyles;
};

var styledWrapper = function styledWrapper(tag) {
  return function (strings) {
    var hydratedTemplateString = getHydratedTemplateString(strings);
    for (
      var _len = arguments.length,
        expressions = new Array(_len > 1 ? _len - 1 : 0),
        _key = 1;
      _key < _len;
      _key++
    ) {
      expressions[_key - 1] = arguments[_key];
    }

    return styled(tag)(hydratedTemplateString, ...expressions);
  };
};
```

</details>

# Issues faced:

- [x]  Need to test things with object pattern i.e `styled.div`
- [x]  Need to test `styled(Banner)` pattern.
- [x] Test swind classes

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
