### PR TITLE
fix: Include 'xl' while generating font-size rules

### DIFF
--- a/src/services/css-gen/css-gen.spec.ts
+++ b/src/services/css-gen/css-gen.spec.ts
@@ -70,6 +70,12 @@ describe('CSSGen', () => {
     expect(css).toMatchInlineSnapshot(`"font-size: 4rem;"`);
   });
 
+  it('should generate css for text size xl', () => {
+    const css = cssGen.genCSS(['.text-xl']);
+
+    expect(css).toMatchInlineSnapshot(`"font-size: 1.25rem;"`);
+  });
+
   it('should generate css for text weight', () => {
     const css = cssGen.genCSS(['.font-bold']);
 

--- a/src/services/css-gen/css-gen.ts
+++ b/src/services/css-gen/css-gen.ts
@@ -254,7 +254,7 @@ export class CSSGen {
     BORDER_OPACITY: /^border-opacity-[0-9]/,
     BORDER_COLOR: /^border-(?!opacity)(.*)-[0-9]/,
     BORDER_WITH_DIRECTION: /^border-(.)-[0-9]/,
-    TEXT_SIZE: /^text-(xs|sm|base|lg|[0-9]xl)$/,
+    TEXT_SIZE: /^text-(xs|sm|base|lg|xl|[2-9]xl)$/,
     TEXT_WEIGHT: /^font-(hairline|thin|light|normal|medium|semibold|bold|extrabold|black)$/,
     TEXT_OPACITY: /^text-opacity-[0-9]/,
     TEXT_COLOR: /^text-(?!opacity)(.*)/,
@@ -436,7 +436,7 @@ export class CSSGen {
       ) {
         const props = styledClassName.split('-');
 
-        // text-black, text-trasparent
+        // text-black, text-transparent
         if (props.length === 2) {
           const [textOrPlaceholder, colorString] = props;
           const colorHex = this.config.theme.colors[colorString];


### PR DESCRIPTION
# Fixes text-xl Bug

`text-xl` was not being detected as font-size related class, instead falls back to color relate property like `text-transparent`. So as per issue, `color: undefined` was generated. The fix has been done by modifying the pattern to separately detect `xl` like `lg`, `sm` prefixes. 

Also since we don't expect a class name like `text-1xl` or `text-0xl` modified the numbers to start from 2 instead. (widths, borders, opacity, etc. can be 0, unlike font-sizes) 

Fixes #32 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

